### PR TITLE
Use Plasmo Browser Extension Package for Browser Storage Operation

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "author": "MichaelYuhe",
   "license": "MIT",
   "dependencies": {
+    "@plasmohq/storage": "^1.9.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@plasmohq/storage':
+    specifier: ^1.9.0
+    version: 1.9.0(react@18.2.0)
   react:
     specifier: ^18.2.0
     version: 18.2.0
@@ -314,6 +317,18 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
     dev: true
+
+  /@plasmohq/storage@1.9.0(react@18.2.0):
+    resolution: {integrity: sha512-mntoJ0EVh7JfYyMKWKnt6yqVlJnwavEkwdXssSOxS1CEeyNX2GPkXQfChvlGhuEJplqcRhLaym6rEc690Ao0fg==}
+    peerDependencies:
+      react: ^16.8.6 || ^17 || ^18
+    peerDependenciesMeta:
+      react:
+        optional: true
+    dependencies:
+      pify: 6.1.0
+      react: 18.2.0
+    dev: false
 
   /@rollup/rollup-android-arm-eabi@4.7.0:
     resolution: {integrity: sha512-rGku10pL1StFlFvXX5pEv88KdGW6DHUghsxyP/aRYb9eH+74jTGJ3U0S/rtlsQ4yYq1Hcc7AMkoJOb1xu29Fxw==}
@@ -1223,6 +1238,11 @@ packages:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
     dev: true
+
+  /pify@6.1.0:
+    resolution: {integrity: sha512-KocF8ve28eFjjuBKKGvzOBGzG8ew2OqOOSxTTZhirkzH7h3BI1vyzqlR0qbfcDBve1Yzo3FVlWUAtCRrbVN8Fw==}
+    engines: {node: '>=14.16'}
+    dev: false
 
   /pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,21 +1,18 @@
 import { handleOneTab } from "./services";
-import { getStorage } from "./utils";
+import { Storage } from "@plasmohq/storage";
 
-let types: string[] = [];
+const main = async () => {
+  const tabMap = new Map<string, number>();
+  const storage = new Storage();
+  let types: string[] = (await storage.get<string[]>("types")) || [];
 
-chrome.storage.local.get("types", (result) => {
-  if (result.types) {
-    types = result.types;
-  }
-});
-
-const tabMap = new Map<string, number>();
-
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-  chrome.storage.local.get("types", (resultStorage) => {
-    if (resultStorage.types) {
-      types = resultStorage.types;
-
+  chrome.runtime.onMessage.addListener(
+    async (message, sender, sendResponse) => {
+      const typesFromStorage: string[] = await storage.get("types");
+      if (!typesFromStorage) {
+        return;
+      }
+      types = typesFromStorage;
       const result = message.result;
       types.forEach((_, i) => {
         // Check if result[i] exists before accessing the 'type' property
@@ -27,109 +24,111 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         }
       });
     }
-  });
-});
-
-chrome.tabGroups.onUpdated.addListener((group) => {
-  if (!group.title) return;
-  const type = group.title;
-
-  if (tabMap.has(type)) return;
-
-  tabMap.set(type, group.id);
-});
-
-async function groupOneType(type: string, tabIds: number[]) {
-  if (tabIds.length === 0) return;
-
-  chrome.tabs.group({ tabIds }, async (groupId) => {
-    await chrome.tabGroups.update(groupId, { title: type });
-  });
-}
-
-async function createGroupWithTitle(tabId: number, title: string) {
-  try {
-    const groupId = await chrome.tabs.group({ tabIds: [tabId] });
-    await chrome.tabGroups.update(groupId, { title });
-    tabMap.set(title, groupId);
-  } catch (error) {
-    console.error("Error creating tab group:", error);
-    throw error;
-  }
-}
-
-async function processTabAndGroup(tab: chrome.tabs.Tab, types: any) {
-  if (!tab.id) {
-    throw new Error("Tab ID is undefined!");
-  }
-  const openAIKey = await getStorage<string>("openai_key");
-  if (!openAIKey) return;
-
-  const type = await handleOneTab(tab, types, openAIKey);
-
-  // Query all groups and update tabMap accordingly
-  const allGroups = await chrome.tabGroups.query({});
-  allGroups.forEach(
-    (group) => group.title && tabMap.set(group.title, group.id)
   );
 
-  // Check if a group already exists for this type
-  const groupId = tabMap.get(type);
+  chrome.tabGroups.onUpdated.addListener((group) => {
+    if (!group.title) return;
+    const type = group.title;
 
-  // If groupId is not undefined, it means a group with that type already exists
-  if (groupId !== undefined) {
-    // Existing group is valid, add tab to this group.
-    await chrome.tabs.group({ tabIds: tab.id, groupId });
-  } else {
-    // If no valid group is found, create a new group for this type
-    await createGroupWithTitle(tab.id, type);
+    if (tabMap.has(type)) return;
+
+    tabMap.set(type, group.id);
+  });
+
+  async function groupOneType(type: string, tabIds: number[]) {
+    if (tabIds.length === 0) return;
+
+    chrome.tabs.group({ tabIds }, async (groupId) => {
+      await chrome.tabGroups.update(groupId, { title: type });
+    });
   }
-}
 
-async function handleNewTab(tab: chrome.tabs.Tab) {
-  const enable = await getStorage<boolean>("isOn");
-  const window = await chrome.windows.get(tab.windowId);
-  if (
-    !enable ||
-    !tab.id ||
-    !tab.url ||
-    window.type != "normal" ||
-    !types.length ||
-    (tab.status === "complete" && tab.url.startsWith("chrome://"))
+  async function createGroupWithTitle(tabId: number, title: string) {
+    try {
+      const groupId = await chrome.tabs.group({ tabIds: [tabId] });
+      await chrome.tabGroups.update(groupId, { title });
+      tabMap.set(title, groupId);
+    } catch (error) {
+      console.error("Error creating tab group:", error);
+      throw error;
+    }
+  }
+
+  async function processTabAndGroup(tab: chrome.tabs.Tab, types: any) {
+    if (!tab.id) {
+      throw new Error("Tab ID is undefined!");
+    }
+    const openAIKey = await storage.get<string>("openai_key");
+    if (!openAIKey) return;
+
+    const type = await handleOneTab(tab, types, openAIKey);
+
+    // Query all groups and update tabMap accordingly
+    const allGroups = await chrome.tabGroups.query({});
+    allGroups.forEach(
+      (group) => group.title && tabMap.set(group.title, group.id)
+    );
+
+    // Check if a group already exists for this type
+    const groupId = tabMap.get(type);
+
+    // If groupId is not undefined, it means a group with that type already exists
+    if (groupId !== undefined) {
+      // Existing group is valid, add tab to this group.
+      await chrome.tabs.group({ tabIds: tab.id, groupId });
+    } else {
+      // If no valid group is found, create a new group for this type
+      await createGroupWithTitle(tab.id, type);
+    }
+  }
+
+  async function handleNewTab(tab: chrome.tabs.Tab) {
+    const enable = await storage.get<boolean>("isOn");
+    const window = await chrome.windows.get(tab.windowId);
+    if (
+      !enable ||
+      !tab.id ||
+      !tab.url ||
+      window.type != "normal" ||
+      !types.length ||
+      (tab.status === "complete" && tab.url.startsWith("chrome://"))
+    ) {
+      return;
+    }
+    try {
+      await processTabAndGroup(tab, types);
+    } catch (error) {
+      console.error("Error in handleNewTab:", error);
+    }
+  }
+
+  async function handleTabUpdate(
+    tabId: number,
+    changeInfo: chrome.tabs.TabChangeInfo,
+    tab: chrome.tabs.Tab
   ) {
-    return;
-  }
-  try {
-    await processTabAndGroup(tab, types);
-  } catch (error) {
-    console.error("Error in handleNewTab:", error);
-  }
-}
+    const enable = await storage.get<boolean>("isOn");
+    const window = await chrome.windows.get(tab.windowId);
+    if (
+      !enable ||
+      !tab.id ||
+      !tab.url ||
+      window.type != "normal" ||
+      tab.url.startsWith("chrome://") ||
+      changeInfo.status !== "complete"
+    ) {
+      return;
+    }
 
-async function handleTabUpdate(
-  tabId: number,
-  changeInfo: chrome.tabs.TabChangeInfo,
-  tab: chrome.tabs.Tab
-) {
-  const enable = await getStorage<boolean>("isOn");
-  const window = await chrome.windows.get(tab.windowId);
-  if (
-    !enable ||
-    !tab.id ||
-    !tab.url ||
-    window.type != "normal" ||
-    tab.url.startsWith("chrome://") ||
-    changeInfo.status !== "complete"
-  ) {
-    return;
+    try {
+      await processTabAndGroup(tab, types);
+    } catch (error) {
+      console.error("Error in handleTabUpdate:", error);
+    }
   }
 
-  try {
-    await processTabAndGroup(tab, types);
-  } catch (error) {
-    console.error("Error in handleTabUpdate:", error);
-  }
-}
+  chrome.tabs.onCreated.addListener(handleNewTab);
+  chrome.tabs.onUpdated.addListener(handleTabUpdate);
+};
 
-chrome.tabs.onCreated.addListener(handleNewTab);
-chrome.tabs.onUpdated.addListener(handleTabUpdate);
+main();

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -1,28 +1,18 @@
-import React, { ChangeEvent, useCallback, useEffect, useState } from "react";
+import React from "react";
 import { createRoot } from "react-dom/client";
 import "./options.css";
-import { getStorage, setStorage } from "./utils";
+import { useStorage } from "@plasmohq/storage/hook";
+import { getValueOrPersistDefault } from "./utils";
 
 const Options = () => {
-  const [model, setModel] = useState<string | undefined>("gpt-3.5-turbo");
-  const [apiURL, setApiURL] = useState<string | undefined>(
-    "https://api.openai.com/v1/chat/completions"
+  const [model, setModel] = useStorage<string>(
+    "model",
+    getValueOrPersistDefault("gpt-3.5-turbo")
   );
-
-  useEffect(() => {
-    getStorage<string>("model").then(setModel);
-    getStorage<string>("apiURL").then(setApiURL);
-  }, []);
-
-  const updateModel = useCallback((e: ChangeEvent<HTMLSelectElement>) => {
-    setModel(e.target.value);
-    setStorage("model", e.target.value);
-  }, []);
-
-  const updateApiURL = useCallback((e: ChangeEvent<HTMLInputElement>) => {
-    setApiURL(e.target.value);
-    setStorage("apiURL", e.target.value);
-  }, []);
+  const [apiURL, setApiURL] = useStorage<string>(
+    "apiURL",
+    getValueOrPersistDefault("https://api.openai.com/v1/chat/completions")
+  );
 
   return (
     <div className="w-screen h-screen flex justify-center p-12">
@@ -38,7 +28,7 @@ const Options = () => {
 
           <select
             value={model}
-            onChange={updateModel}
+            onChange={(e) => setModel(e.target.value)}
             id="models"
             className="bg-gray-50 border w-64 border-gray-300 text-gray-900 text-sm rounded-lg 
           focus:ring-blue-500 focus:border-blue-500 block"
@@ -60,7 +50,7 @@ const Options = () => {
             className="bg-gray-50 border w-64 border-gray-300 text-gray-900 text-sm rounded-lg 
           focus:ring-blue-500 focus:border-blue-500 block"
             value={apiURL}
-            onChange={updateApiURL}
+            onChange={(e) => setApiURL(e.target.value)}
             id="api_url"
           />
         </div>

--- a/src/services.ts
+++ b/src/services.ts
@@ -1,4 +1,4 @@
-import { getStorage } from "./utils";
+import { Storage } from "@plasmohq/storage";
 
 interface TabGroup {
   type: string;
@@ -25,9 +25,11 @@ export async function batchGroupTabs(
     };
   });
 
-  const model = (await getStorage("model")) || "gpt-3.5-turbo";
-  const apiURL =
-    (await getStorage("apiURL")) ||
+  const storage = new Storage();
+
+  const model: string = (await storage.get<string>("model")) || "gpt-3.5-turbo";
+  const apiURL: string =
+    (await storage.get<string>("apiURL")) ||
     "https://api.openai.com/v1/chat/completions";
 
   try {
@@ -81,9 +83,11 @@ export async function handleOneTab(
   openAIKey: string
 ) {
   try {
-    const model = (await getStorage("model")) || "gpt-3.5-turbo";
-    const apiURL =
-      (await getStorage("apiURL")) ||
+    const storage = new Storage();
+    const model: string =
+      (await storage.get<string>("model")) || "gpt-3.5-turbo";
+    const apiURL: string =
+      (await storage.get<string>("apiURL")) ||
       "https://api.openai.com/v1/chat/completions";
 
     const response = await fetch(apiURL, {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,26 +1,5 @@
-export function setStorage<V = any>(key: string, value: V) {
-  return new Promise((resolve, reject) => {
-    chrome.storage.local.set({ [key]: value }, () => {
-      if (chrome.runtime.lastError) {
-        reject(chrome.runtime.lastError);
-      } else {
-        resolve(true);
-      }
-    });
-  });
-}
-
-export function getStorage<V = any>(key: string): Promise<V | undefined> {
-  return new Promise((resolve, reject) => {
-    chrome.storage.local.get(key, (result) => {
-      if (chrome.runtime.lastError) {
-        reject(chrome.runtime.lastError);
-      } else {
-        resolve(result[key]);
-      }
-    });
-  });
-}
+export const getValueOrPersistDefault = (defaultValue: any) => (v: any) =>
+  v === undefined ? defaultValue : v;
 
 export const DEFAULT_GROUP = [
   "Social",


### PR DESCRIPTION
## Why
Chrome(and other browsers) API operation usually is error-prune. This PR introduces https://docs.plasmo.com/framework/storage to replace current implementation, as Plasmo has been widely tested by more developers and products, and it also brings us an easy API to work with, to allow us to focus on the business logic of the tab management itself, rather than dealing with Chrome API.

## What
This PR replaces `getStorage` and `setStorage` with Plasmo Storage API. I intend to introduce Plasmo to messaging and other parts, but leave this extended part open for discussion.

## Test
Manually tested all main use cases:
1. Set OpenAI key
2. Add and delete group types
3. Set OpenAI model and API url
4. Group all existing tabs
5. Auto group new tabs
