### PR TITLE
[bug fix] Fix auto grouping doesn't work because isOn is undefined by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.7",
-    "@types/chrome": "0.0.158",
+    "@types/chrome": "0.0.254",
     "@types/node": "^20.10.4",
     "@types/react": "^18.0.29",
     "@types/react-dom": "^18.0.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ devDependencies:
     specifier: ^0.5.7
     version: 0.5.7(tailwindcss@3.3.6)
   '@types/chrome':
-    specifier: 0.0.158
-    version: 0.0.158
+    specifier: 0.0.254
+    version: 0.0.254
   '@types/node':
     specifier: ^20.10.4
     version: 20.10.4
@@ -541,8 +541,8 @@ packages:
       tailwindcss: 3.3.6
     dev: true
 
-  /@types/chrome@0.0.158:
-    resolution: {integrity: sha512-sjBs9E/XDlYyLf3YkPYIN6sFZ/d9LbwMSK+BYphenFdkk39M5P8xcRfykk54RgZr8/QMex1yKlX5EB52TaqhsQ==}
+  /@types/chrome@0.0.254:
+    resolution: {integrity: sha512-svkOGKwA+6ZZuk9xtrYun8MYpNY/9hD17rgZ19v3KunhsK1ZOKaMESw12/1AXLh1u3UPA8jQIRi2370DXv9wgw==}
     dependencies:
       '@types/filesystem': 0.0.35
       '@types/har-format': 1.2.15

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,5 +1,12 @@
 import { handleOneTab } from "./services";
-import { getStorage } from "./utils";
+import { DEFAULT_GROUP, getStorage, setStorage } from "./utils";
+
+chrome.runtime.onInstalled.addListener((details) => {
+  if (details.reason === chrome.runtime.OnInstalledReason.INSTALL) {
+    setStorage<boolean>("isOn", true);
+    setStorage<string[]>("types", DEFAULT_GROUP);
+  }
+});
 
 let types: string[] = [];
 


### PR DESCRIPTION
Theres' a bug that auto grouping doesn't work.

This is because in `background.ts`, it executes auto grouping only when Chrome local storage `isOn` is `true`.
```typescript
const enable = await getStorage<boolean>("isOn");
  if (
    !enable ||
    !tab.id ||
    !tab.url ||
    window.type != "normal" ||
    !types.length ||
    (tab.status === "complete" && tab.url.startsWith("chrome://"))
  ) {
    return;
  }
```

However, `isOn` is by default `undefined`, because `popup.tsx` doesn't store `isOn` value to Chrome local storage, as the only place it sets is when user clicks on `disableGrouping`. 
```typescript
  const disableGrouping = () => {
    setIsOn((isOn) => {
      setStorage("isOn", !isOn);
      return !isOn;
    });
  };
```

Since `isOn` is `undefined`, `backtround.ts` won't execute auto grouping.

This PR fixes this.

---

#48 is aimed to avoid such bugs when these states should have been synced across browser storage and React states.
