### PR TITLE
[feature] Enable user to customize prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   "author": "MichaelYuhe",
   "license": "MIT",
   "dependencies": {
+    "@types/mustache": "4.1.0",
+    "mustache": "4.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,12 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@types/mustache':
+    specifier: 4.1.0
+    version: 4.1.0
+  mustache:
+    specifier: 4.1.0
+    version: 4.1.0
   react:
     specifier: ^18.2.0
     version: 18.2.0
@@ -561,6 +567,10 @@ packages:
   /@types/har-format@1.2.15:
     resolution: {integrity: sha512-RpQH4rXLuvTXKR0zqHq3go0RVXYv/YVqv4TnPH95VbwUxZdQlK1EtcMvQvMpDngHbt13Csh9Z4qT9AbkiQH5BA==}
     dev: true
+
+  /@types/mustache@4.1.0:
+    resolution: {integrity: sha512-dj4gq0BwsONZw/jqEf1qDBkAhAdBfIb7K+RDEQQvGfd6uTkfzKNxjz6NCeg50bveU0ydi8DruGp/9+FgIxli5w==}
+    dev: false
 
   /@types/node@20.10.4:
     resolution: {integrity: sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==}
@@ -1119,6 +1129,11 @@ packages:
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
     dev: true
+
+  /mustache@4.1.0:
+    resolution: {integrity: sha512-0FsgP/WVq4mKyjolIyX+Z9Bd+3WS8GOwoUTyKXT5cTYMGeauNTi2HPCwERqseC1IHAy0Z7MDZnJBfjabd4O8GQ==}
+    hasBin: true
+    dev: false
 
   /mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,10 +1,11 @@
 import { handleOneTab } from "./services";
-import { DEFAULT_GROUP, getStorage, setStorage } from "./utils";
+import { DEFAULT_GROUP, DEFAULT_PROMPT, getStorage, setStorage } from "./utils";
 
 chrome.runtime.onInstalled.addListener((details) => {
   if (details.reason === chrome.runtime.OnInstalledReason.INSTALL) {
     setStorage<boolean>("isOn", true);
     setStorage<string[]>("types", DEFAULT_GROUP);
+    setStorage<string>("prompt", DEFAULT_PROMPT);
   }
 });
 
@@ -94,10 +95,7 @@ async function processTabAndGroup(tab: chrome.tabs.Tab, types: any) {
 }
 
 async function handleNewTab(tab: chrome.tabs.Tab) {
-  let enable = await getStorage<boolean>("isOn");
-  if (enable === undefined) {
-    enable = true;
-  }
+  const enable = await getStorage<boolean>("isOn");
   const window = await chrome.windows.get(tab.windowId);
   if (
     !enable ||
@@ -121,10 +119,7 @@ async function handleTabUpdate(
   changeInfo: chrome.tabs.TabChangeInfo,
   tab: chrome.tabs.Tab
 ) {
-  let enable = await getStorage<boolean>("isOn");
-  if (enable === undefined) {
-    enable = true;
-  }
+  const enable = await getStorage<boolean>("isOn");
   const window = await chrome.windows.get(tab.windowId);
   if (
     !enable ||

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -100,7 +100,6 @@ const Options = () => {
               className=" w-64 bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative"
               role="alert"
             >
-              {/* <strong className="font-bold">Holy smokes!</strong> */}
               <span className="block sm:inline">{promptFormatWarning}</span>
             </div>
           )}

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -1,17 +1,21 @@
 import React, { ChangeEvent, useCallback, useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
 import "./options.css";
-import { getStorage, setStorage } from "./utils";
+import { DEFAULT_PROMPT, getStorage, setStorage } from "./utils";
 
 const Options = () => {
   const [model, setModel] = useState<string | undefined>("gpt-3.5-turbo");
   const [apiURL, setApiURL] = useState<string | undefined>(
     "https://api.openai.com/v1/chat/completions"
   );
+  const [prompt, setPrompt] = useState<string | undefined>(DEFAULT_PROMPT);
+  const [isPromptValid, setIsPromptValid] = useState<boolean>(true);
+  const promptFormatWarning: string = `{{tabURL}}, {{tabTitle}} and {{types}} must be in the prompt`;
 
   useEffect(() => {
     getStorage<string>("model").then(setModel);
     getStorage<string>("apiURL").then(setApiURL);
+    getStorage<string>("prompt").then(setPrompt);
   }, []);
 
   const updateModel = useCallback((e: ChangeEvent<HTMLSelectElement>) => {
@@ -22,6 +26,19 @@ const Options = () => {
   const updateApiURL = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     setApiURL(e.target.value);
     setStorage("apiURL", e.target.value);
+  }, []);
+
+  const updatePrompt = useCallback((e: ChangeEvent<HTMLTextAreaElement>) => {
+    const newPrompt: string = e.target.value;
+    setIsPromptValid(
+      /{{tabURL}}/.test(newPrompt) &&
+        /{{tabTitle}}/.test(newPrompt) &&
+        /{{types}}/.test(newPrompt)
+    );
+    if (isPromptValid) {
+      setPrompt(newPrompt);
+      setStorage("prompt", newPrompt);
+    }
   }, []);
 
   return (
@@ -62,6 +79,38 @@ const Options = () => {
             value={apiURL}
             onChange={updateApiURL}
             id="api_url"
+          />
+        </div>
+
+        <div className="flex flex-col gap-y-2">
+          <label htmlFor="prompt" className="text-xl font-medium">
+            Prompt
+          </label>
+          {isPromptValid && (
+            <label
+              htmlFor="prompt"
+              className="text-sm font-normal w-64 text-blue-500"
+            >
+              {promptFormatWarning}
+            </label>
+          )}
+
+          {!isPromptValid && (
+            <div
+              className=" w-64 bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative"
+              role="alert"
+            >
+              {/* <strong className="font-bold">Holy smokes!</strong> */}
+              <span className="block sm:inline">{promptFormatWarning}</span>
+            </div>
+          )}
+
+          <textarea
+            className="bg-gray-50 border w-64 h-64 border-gray-300 text-gray-900 text-sm rounded-lg 
+          focus:ring-blue-500 focus:border-blue-500 block"
+            value={prompt}
+            onChange={updatePrompt}
+            id="prompt"
           />
         </div>
       </div>

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -10,15 +10,13 @@ import Input from "./components/Input";
 const Popup = () => {
   const [openAIKey, setOpenAIKey] = useState<string | undefined>("");
   const [types, setTypes] = useState<string[]>([]);
-  const [isOn, setIsOn] = useState<boolean>(true);
+  const [isOn, setIsOn] = useState<boolean | undefined>(true);
   const [newType, setNewType] = useState<string>("");
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
   useEffect(() => {
     getStorage<string>("openai_key").then(setOpenAIKey);
-    getStorage<boolean>("isOn").then((v) => {
-      setIsOn(v === undefined ? true : v);
-    });
+    getStorage<boolean>("isOn").then(setIsOn);
     getStorage<string[]>("types").then((types) => {
       if (!types) {
         setTypes(DEFAULT_GROUP);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,3 +30,8 @@ export const DEFAULT_GROUP = [
   "Productivity",
   "Utilities",
 ];
+
+export const DEFAULT_PROMPT: string =
+  `Based on the URL: "{{tabURL}}" and title: "{{tabTitle}}", ` +
+  `classify the browser tab type as one of the following: "{{types}}". ` +
+  `Respond with only the classification keyword from the list.`;


### PR DESCRIPTION
This PR allows user to customize prompt in Options page, while enabling them to do however they want with `{{tabURL}}`, `{{tabTitle}}`, and `{{types}}` which the code will inject into the prompt. Addressed part of #38 

Below are screenshots of how editing the prompt in Options page look like:

![CleanShot 2023-12-12 at 02 58 05@2x](https://github.com/MichaelYuhe/ai-group-tabs/assets/7776499/75b814c7-66bb-4539-9779-e0467b24c56f)
![CleanShot 2023-12-12 at 02 58 34@2x](https://github.com/MichaelYuhe/ai-group-tabs/assets/7776499/0702adca-a192-4d19-addc-689232a0f441)
