### PR TITLE
Clear url query parameters of url before rendering for privacy protection

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -210,7 +210,9 @@ async function handleNewTab(tab: chrome.tabs.Tab) {
     !tab.id ||
     !tab.url ||
     window.type != "normal" ||
-    !types.length
+    !types.length ||
+    tab.url?.startsWith("chrome") ||
+    tab.url.startsWith("about")
   ) {
     return;
   }
@@ -228,7 +230,14 @@ async function handleTabUpdate(
   const enable = await getStorage<boolean>("isOn");
   const window = await chrome.windows.get(tab.windowId);
 
-  if (!enable || !tab.id || !tab.url) return;
+  if (
+    !enable ||
+    !tab.id ||
+    !tab.url ||
+    tab.url.startsWith("chrome") ||
+    tab.url.startsWith("about")
+  )
+    return;
 
   const oldTab = tabMap[tab.id];
   if (

--- a/src/service-provider/gemini.ts
+++ b/src/service-provider/gemini.ts
@@ -1,6 +1,6 @@
 import { TabInfo } from "../types";
 import Mustache from "mustache";
-import { getStorage } from "../utils";
+import { getStorage, removeQueryParameters } from "../utils";
 import { DEFAULT_PROMPT } from "../const";
 
 const renderPromptForGemini = async (
@@ -30,7 +30,7 @@ const renderPromptForGemini = async (
       parts: [
         {
           text: Mustache.render(prompt, {
-            tabURL: tab.url,
+            tabURL: removeQueryParameters(tab.url),
             tabTitle: tab.title,
             types: types.join(", "),
           }),

--- a/src/service-provider/gpt.ts
+++ b/src/service-provider/gpt.ts
@@ -1,6 +1,6 @@
 import { TabInfo } from "../types";
 import Mustache from "mustache";
-import { getStorage } from "../utils";
+import { getStorage, removeQueryParameters } from "../utils";
 import { DEFAULT_PROMPT } from "../const";
 
 const renderPromptForOpenAI = async (
@@ -18,7 +18,7 @@ const renderPromptForOpenAI = async (
     {
       role: "user",
       content: Mustache.render(prompt, {
-        tabURL: tab.url,
+        tabURL: removeQueryParameters(tab.url),
         tabTitle: tab.title,
         types: types.join(", "),
       }),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -133,3 +133,14 @@ export const getServiceProvider = async () => {
     (await getStorage<ServiceProvider>("serviceProvider")) || "GPT";
   return serviceProvider;
 };
+
+export const removeQueryParameters = (
+  urlString: string | undefined
+): string => {
+  if (typeof urlString !== "string") {
+    return "about:blank";
+  }
+  const url = new URL(urlString);
+  url.search = "";
+  return url.toString();
+};


### PR DESCRIPTION
- remove the URL query parameters, it might reduce the accuracy, but it is necessary for privacy protection as query parameters might include sensive information
- ignore grouping chrome special pages like chrome://about chrome://extensions etc.