### PR TITLE
feat: add experiment smart group base text embedding

### DIFF
--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -11,6 +11,7 @@ import { toast } from "./components/toast";
 import { ServiceProvider } from "./types";
 
 import "./popup.css";
+import { getDomainMatchedType } from "./service-provider/openai-embeddings";
 
 const getApiKeyHrefMap = {
   Gemini: "https://ai.google.dev/",
@@ -233,6 +234,22 @@ const Popup = () => {
     setIsValidating(false);
   };
 
+  const smartGroup = async () => {
+    console.log("smartGroup");
+
+    if (!apiKey) {
+      return;
+    }
+    const tabs = await chrome.tabs.query({ currentWindow: true });
+    // TODO filter out tabs that match filterRules
+    for (const tab of tabs) {
+      if (!tab.url) continue;
+      const matchData = await getDomainMatchedType(apiKey, tab.url);
+      // TODO group tab
+      console.log(tab.url, matchData?.type, matchData);
+    }
+  };
+
   return (
     <div className="p-6 pb-9 min-w-[24rem] ">
       <div className="flex items-center mb-6 justify-between">
@@ -299,7 +316,7 @@ const Popup = () => {
           disabled={!apiKey || !types || !types.length}
           className="inline-flex items-center rounded-md bg-primary/lg px-2.5 py-1.5 text-sm font-semibold
         text-white shadow-sm hover:bg-primary focus-visible:outline cursor-pointer
-        focus-visible:outline-2 focus-visible:outline-offset-2"
+        focus-visible:outline-2 focus-visible:outline-offset-2 whitespace-nowrap"
           onClick={getAllTabsInfo}
         >
           {isLoading && <LoadingSpinner />}
@@ -309,10 +326,18 @@ const Popup = () => {
         <button
           className="inline-flex items-center rounded-md bg-primary/lg px-2.5 py-1.5 text-sm font-semibold
         text-white shadow-sm hover:bg-primary focus-visible:outline cursor-pointer
-        focus-visible:outline-2 focus-visible:outline-offset-2"
+        focus-visible:outline-2 focus-visible:outline-offset-2 whitespace-nowrap"
           onClick={ungroup}
         >
           Ungroup All
+        </button>
+        <button
+          className="inline-flex items-center rounded-md bg-primary/lg px-2.5 py-1.5 text-sm font-semibold
+        text-white shadow-sm hover:bg-primary focus-visible:outline cursor-pointer
+        focus-visible:outline-2 focus-visible:outline-offset-2 whitespace-nowrap"
+          onClick={smartGroup}
+        >
+          Smart Group
         </button>
       </div>
 

--- a/src/service-provider/openai-embeddings.ts
+++ b/src/service-provider/openai-embeddings.ts
@@ -1,0 +1,127 @@
+import { getStorage, setStorage } from "../utils";
+
+interface PreviewData {
+  url: string;
+  title?: string;
+  siteName?: string;
+  description?: string;
+  images?: string[];
+  mediaType?: string;
+  contentType?: string;
+  charset?: string;
+  videos?: string[];
+  favicons?: string[];
+}
+
+export const getLinkPreview = async (url: string) => {
+  // TODO deploy to our own worker
+  // See https://github.com/OP-Engineering/link-preview-js
+  const response = await fetch(
+    "https://affine-worker.toeverything.workers.dev/api/worker/linkPreview",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        url,
+      }),
+    }
+  );
+  if (response.status !== 200) {
+    return;
+  }
+  const data: PreviewData = await response.json();
+  for (const key in data) {
+    const k = key as keyof PreviewData;
+    if (!data[k]) {
+      delete data[k];
+    }
+  }
+  return data;
+};
+
+export interface EmbeddingResult {
+  object: "list" | string;
+  data: {
+    object: "embedding";
+    embedding: number[];
+    index: number;
+  }[];
+  model: "text-embedding-ada-002" | string;
+  usage: {
+    prompt_tokens: number;
+    total_tokens: number;
+  };
+}
+
+const fetchEmbedding = async (apiKey: string, text: string) => {
+  const apiURL =
+    (await getStorage("apiURL")) || "https://api.openai.com/v1/embeddings";
+
+  // OpenAI recommend using `text-embedding-ada-002` for nearly all use cases.
+  // See https://platform.openai.com/docs/guides/embeddings/embedding-models
+  const model = "text-embedding-ada-002";
+
+  // See https://platform.openai.com/docs/api-reference/embeddings/create
+  const response = await fetch(apiURL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      input: text,
+      model,
+      // encoding_format: "base64",
+    }),
+  });
+
+  const data: EmbeddingResult = await response.json();
+  const embedding = data.data[0].embedding;
+  return embedding;
+};
+
+type EmbeddingData = {
+  preview: PreviewData;
+  embedding: number[];
+  timestamp: number;
+};
+
+const getDomainEmbedding = async (
+  apiKey: string,
+  hostname: string
+): Promise<EmbeddingData | undefined> => {
+  const preview = await getLinkPreview(hostname);
+  if (!preview) return;
+  const text = [
+    preview.url,
+    preview.siteName,
+    preview.title,
+    preview.description,
+  ]
+    .filter(Boolean)
+    .join("\n");
+  const embedding = await fetchEmbedding(apiKey, text);
+  return {
+    preview,
+    embedding,
+    timestamp: Date.now(),
+  };
+};
+
+export const getDomainEmbeddingWithCache = async (
+  apiKey: string,
+  url: string
+) => {
+  const hostname = new URL(url).hostname;
+  const cacheKey = `embedding-${hostname}`;
+  const cache = await getStorage<number[]>(cacheKey);
+  if (cache) {
+    return cache;
+  }
+  const embedding = await getDomainEmbedding(apiKey, hostname);
+  if (!embedding) return;
+  await setStorage(cacheKey, embedding);
+  return embedding;
+};

--- a/src/service-provider/openai-embeddings.ts
+++ b/src/service-provider/openai-embeddings.ts
@@ -1,4 +1,126 @@
-import { getStorage, setStorage } from "../utils";
+import { cosineSimilarity, getStorage, setStorage } from "../utils";
+
+// W3C Standardized categories
+// See https://github.com/w3c/manifest/wiki/Categories
+export const DEFAULT_GROUP = [
+  { name: "Books", desc: "A collection of books and literature resources." },
+  {
+    name: "Business",
+    desc: "Resources related to business operations and finance.",
+  },
+  { name: "Education", desc: "Educational resources and learning materials." },
+  {
+    name: "Entertainment",
+    desc: "Entertainment resources including movies, music, and TV shows.",
+  },
+  {
+    name: "Finance",
+    desc:
+      "Financial resources including banking, investing, and personal finance.",
+  },
+  {
+    name: "Fitness",
+    desc: "Fitness resources including workout routines and health tips.",
+  },
+  {
+    name: "Food",
+    desc:
+      "Food resources including recipes, cooking tips, and nutrition information.",
+  },
+  {
+    name: "Games",
+    desc: "Gaming resources including video games, board games.",
+  },
+  {
+    name: "Government",
+    desc: "Government resources including legal documents and public services.",
+  },
+  {
+    name: "Health",
+    desc: "Health resources including medical information and wellness tips.",
+  },
+  {
+    name: "Kids",
+    desc:
+      "Resources for kids including educational games and child-friendly entertainment.",
+  },
+  {
+    name: "Lifestyle",
+    desc:
+      "Lifestyle resources including fashion, home decor, and personal growth.",
+  },
+  {
+    name: "Magazines",
+    desc: "Magazines and periodicals covering a variety of topics.",
+  },
+  {
+    name: "Medical",
+    desc: "Medical resources including health guides and medical research.",
+  },
+  {
+    name: "Music",
+    desc: "Music resources including songs, albums.",
+  },
+  {
+    name: "Navigation",
+    desc: "Navigation resources including maps and travel guides.",
+  },
+  {
+    name: "News",
+    desc: "News resources including current events and journalism.",
+  },
+  {
+    name: "Personalization",
+    desc: "Resources for personalizing your digital experience.",
+  },
+  // {
+  //   name: "Photo",
+  //   desc:
+  //     "Photography resources including photo editing tools and photography tips.",
+  // },
+  // {
+  //   name: "Politics",
+  //   desc:
+  //     "Political resources including news, analysis, and government documents.",
+  // },
+  {
+    name: "Productivity",
+    desc:
+      "Resources focused on enhancing efficiency and productivity, including tools for task management, note-taking, and time tracking.",
+  },
+  // {
+  //   name: "Security",
+  //   desc:
+  //     "Security resources including cybersecurity tips and secure communication tools.",
+  // },
+  {
+    name: "Shopping",
+    desc: "Shopping resources including product reviews and deal alerts.",
+  },
+  {
+    name: "Social",
+    desc:
+      "Social resources including social networking apps and communication tools.",
+  },
+  {
+    name: "Sports",
+    desc: "Sports resources including news, scores, and team information.",
+  },
+  {
+    name: "Travel",
+    desc: "Travel resources including guides, booking tools, and travel tips.",
+  },
+  // {
+  //   name: "Utilities",
+  //   desc:
+  //     "Utility resources including tools and services to optimize your workflow.",
+  // },
+  {
+    name: "Weather",
+    desc:
+      "Weather resources including forecasts, alerts, and climate information.",
+  },
+] as const;
 
 interface PreviewData {
   url: string;
@@ -17,7 +139,7 @@ export const getLinkPreview = async (url: string) => {
   // TODO deploy to our own worker
   // See https://github.com/OP-Engineering/link-preview-js
   const response = await fetch(
-    "https://affine-worker.toeverything.workers.dev/api/worker/linkPreview",
+    "https://affine-worker.toeverything.workers.dev/api/worker/link-preview",
     {
       method: "POST",
       headers: {
@@ -55,16 +177,21 @@ export interface EmbeddingResult {
   };
 }
 
-const fetchEmbedding = async (apiKey: string, text: string) => {
-  const apiURL =
+export const fetchEmbedding = async (apiKey: string, text: string) => {
+  // TODO support configurable API URL
+  const apiUrl =
     (await getStorage("apiURL")) || "https://api.openai.com/v1/embeddings";
+
+  const embedUrl = apiUrl
+    ? new URL(apiUrl).origin + "/v1/embeddings"
+    : "https://api.openai.com/v1/embeddings";
 
   // OpenAI recommend using `text-embedding-ada-002` for nearly all use cases.
   // See https://platform.openai.com/docs/guides/embeddings/embedding-models
   const model = "text-embedding-ada-002";
 
   // See https://platform.openai.com/docs/api-reference/embeddings/create
-  const response = await fetch(apiURL, {
+  const response = await fetch(embedUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -110,13 +237,13 @@ const getDomainEmbedding = async (
   };
 };
 
-export const getDomainEmbeddingWithCache = async (
+export const getDomainEmbeddingDataWithCache = async (
   apiKey: string,
   url: string
 ) => {
   const hostname = new URL(url).hostname;
   const cacheKey = `embedding-${hostname}`;
-  const cache = await getStorage<number[]>(cacheKey);
+  const cache = await getStorage<EmbeddingData>(cacheKey);
   if (cache) {
     return cache;
   }
@@ -124,4 +251,63 @@ export const getDomainEmbeddingWithCache = async (
   if (!embedding) return;
   await setStorage(cacheKey, embedding);
   return embedding;
+};
+
+type GroupEmbeddingData = {
+  type: string;
+  embedding: number[];
+  timestamp: number;
+};
+
+const getGroupTypeEmbeddingWithCache = async (
+  apiKey: string,
+  { name, desc }: { name: string; desc: string }
+) => {
+  const cacheKey = `embedding-group-v4-${name}`;
+  const cache = await getStorage<GroupEmbeddingData>(cacheKey);
+  if (cache) {
+    return cache;
+  }
+  const embedding = await fetchEmbedding(apiKey, name + "\n" + desc);
+  if (!embedding) return;
+  const embeddingData = {
+    type: name,
+    embedding,
+    timestamp: Date.now(),
+  };
+  await setStorage<GroupEmbeddingData>(cacheKey, embeddingData);
+  return embeddingData;
+};
+
+export const getDomainMatchedType = async (apiKey: string, url: string) => {
+  if (!apiKey) throw new Error("apiKey not found");
+  const embeddingData = await getDomainEmbeddingDataWithCache(apiKey, url);
+  if (!embeddingData) return;
+  let maxSimilarity = 0;
+  let maxMatchType = "Unknown";
+  for (const group of DEFAULT_GROUP) {
+    const groupEmbeddingData = await getGroupTypeEmbeddingWithCache(
+      apiKey,
+      group
+    );
+    if (!groupEmbeddingData) {
+      console.error("groupEmbeddingData not found", group);
+      continue;
+    }
+    const similarity = cosineSimilarity(
+      groupEmbeddingData.embedding,
+      embeddingData.embedding
+    );
+
+    if (similarity > maxSimilarity) {
+      maxSimilarity = similarity;
+      maxMatchType = groupEmbeddingData.type;
+    }
+  }
+  return {
+    url,
+    type: maxMatchType,
+    similarity: maxSimilarity,
+    preview: embeddingData.preview,
+  };
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -144,3 +144,25 @@ export const removeQueryParameters = (
   url.search = "";
   return url.toString();
 };
+
+/**
+ * Cosine similarity
+ * See https://en.wikipedia.org/wiki/Cosine_similarity
+ *
+ * If use the `text-embedding-ada-002` model from openAI API, the embedding length is `1536`.
+ */
+export const cosineSimilarity = (
+  embedding1: number[],
+  embedding2: number[]
+) => {
+  if (embedding1.length !== embedding2.length) {
+    console.error("embedding1", embedding1, "embedding2", embedding2);
+    throw new Error("embedding1 and embedding2 should have same length");
+  }
+  const dotProduct = embedding1.reduce((acc, cur, index) => {
+    return acc + cur * embedding2[index];
+  }, 0);
+  const norm1 = Math.sqrt(embedding1.reduce((acc, cur) => acc + cur * cur, 0));
+  const norm2 = Math.sqrt(embedding2.reduce((acc, cur) => acc + cur * cur, 0));
+  return dotProduct / (norm1 * norm2);
+};


### PR DESCRIPTION
This PR is only for verification purposes, please do not merge it.

I made an attempt to group tabs based on the text embedded from the link preview, but the insufficient information provided in the preview led to unsatisfactory results.

Here are some example data:

```json
{
  "url": "https://github.com/",
  "type": "Books",  // It should be grouped into the Productivity category instead of Game or Books
  "similarity": 0.7600699589640771,
  "preview": {
    "description": "GitHub is where over 100 million developers shape the future of software, together. Contribute to the open source community, manage your Git repositories, review code like a pro, track bugs and fea...",
    "siteName": "GitHub",
    "title": "GitHub: Let’s build from here",
    "url": "https://github.com/"
  }
}
```

```json
{
  "url": "https://en.wikipedia.org/wiki/",
  "type": "News",
  "similarity": 0.785299761399085,
  "preview": {
    "url": "https://en.wikipedia.org/wiki/Main_Page",
    "title": "Wikipedia, the free encyclopedia"
  }
}
```

## References

- [Embeddings - openAI](https://platform.openai.com/docs/guides/embeddings/what-are-embeddings)
- [Create embeddings API - openAI](https://platform.openai.com/docs/api-reference/embeddings/create)
